### PR TITLE
Fixes escaping behavior in code marks and blocks

### DIFF
--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -174,6 +174,35 @@ Array [
 ]
 `;
 
+exports[`code mark with escaped characters 1`] = `
+Array [
+  Object {
+    "data": Object {},
+    "isVoid": false,
+    "nodes": Array [
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [
+              Object {
+                "data": Object {},
+                "object": "mark",
+                "type": "code",
+              },
+            ],
+            "object": "leaf",
+            "text": "<script>alert('foo')</script>",
+          },
+        ],
+        "object": "text",
+      },
+    ],
+    "object": "block",
+    "type": "paragraph",
+  },
+]
+`;
+
 exports[`deleted mark 1`] = `
 Array [
   Object {

--- a/src/__tests__/renderer-test.js
+++ b/src/__tests__/renderer-test.js
@@ -109,6 +109,11 @@ test("code mark", () => {
   expect(getNodes(text)).toMatchSnapshot();
 });
 
+test("code mark with escaped characters", () => {
+  const text = "`<script>alert('foo')</script>`";
+  expect(getNodes(text)).toMatchSnapshot();
+});
+
 test("parses quote", () => {
   const text = `
 > this is a quote

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -193,7 +193,15 @@ class Markdown {
   serializeNode(node, document) {
     if (node.object == "text") {
       const leaves = node.getLeaves();
-      return leaves.map(this.serializeLeaves);
+      const inCodeBlock = !!document.getClosest(node.key, n => {
+        n.type === "code";
+      });
+
+      return leaves.map(leave => {
+        const inCodeMark = !!leave.marks.filter(mark => mark.type === "code")
+          .size;
+        return this.serializeLeaves(leave, !inCodeBlock && !inCodeMark);
+      });
     }
 
     let children = node.nodes.map(node => this.serializeNode(node, document));
@@ -215,8 +223,13 @@ class Markdown {
    * @return {String}
    */
 
-  serializeLeaves(leaves) {
-    const string = new String({ text: leaves.text });
+  serializeLeaves(leaves, escape = true) {
+    let leavesText = leaves.text;
+    if (escape) {
+      // escape markdown characters
+      leavesText = leavesText.replace(/([\\`*{}\[\]()#+\-.!_>])/gi, "\\$1");
+    }
+    const string = new String({ text: leavesText });
     const text = this.serializeString(string);
 
     return leaves.marks.reduce((children, mark) => {
@@ -236,12 +249,9 @@ class Markdown {
    */
 
   serializeString(string) {
-    // escape markdown characters
-    const text = string.text.replace(/([\\`*{}\[\]()#+\-.!_>])/gi, "\\$1");
-
     for (const rule of this.rules) {
       if (!rule.serialize) continue;
-      const ret = rule.serialize(string, text);
+      const ret = rule.serialize(string, string.text);
       if (ret) return ret;
     }
   }


### PR DESCRIPTION
@ara4n used [your commit here](https://github.com/matrix-org/slate-md-serializer/commit/f7c4ad394f5af34d4c623de7909ce95ab78072d3#diff-5326222f837d36fd2bff476584c07621) as a base but found a few issues when running the tests and added additional coverage for inline code.