### PR TITLE
Properly handle multi-line blockquotes

### DIFF
--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -2340,7 +2340,7 @@ Array [
                       Object {
                         "marks": Array [],
                         "object": "leaf",
-                        "text": "this is a list item",
+                        "text": "this is a list item with a quote",
                       },
                     ],
                     "object": "text",
@@ -2360,6 +2360,48 @@ Array [
     ],
     "object": "block",
     "type": "ordered-list",
+  },
+  Object {
+    "data": Object {},
+    "isVoid": false,
+    "nodes": Array [
+      Object {
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
+          Object {
+            "data": Object {},
+            "isVoid": false,
+            "nodes": Array [
+              Object {
+                "data": Object {},
+                "isVoid": false,
+                "nodes": Array [
+                  Object {
+                    "leaves": Array [
+                      Object {
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "this is a quote with a list item",
+                      },
+                    ],
+                    "object": "text",
+                  },
+                ],
+                "object": "block",
+                "type": "paragraph",
+              },
+            ],
+            "object": "block",
+            "type": "list-item",
+          },
+        ],
+        "object": "block",
+        "type": "ordered-list",
+      },
+    ],
+    "object": "block",
+    "type": "block-quote",
   },
 ]
 `;

--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -2395,6 +2395,32 @@ Array [
             "object": "block",
             "type": "list-item",
           },
+          Object {
+            "data": Object {},
+            "isVoid": false,
+            "nodes": Array [
+              Object {
+                "data": Object {},
+                "isVoid": false,
+                "nodes": Array [
+                  Object {
+                    "leaves": Array [
+                      Object {
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "this is the second list item",
+                      },
+                    ],
+                    "object": "text",
+                  },
+                ],
+                "object": "block",
+                "type": "paragraph",
+              },
+            ],
+            "object": "block",
+            "type": "list-item",
+          },
         ],
         "object": "block",
         "type": "ordered-list",

--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -2267,14 +2267,22 @@ Array [
     "isVoid": false,
     "nodes": Array [
       Object {
-        "leaves": Array [
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
           Object {
-            "marks": Array [],
-            "object": "leaf",
-            "text": "this is a quote",
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is a quote",
+              },
+            ],
+            "object": "text",
           },
         ],
-        "object": "text",
+        "object": "block",
+        "type": "paragraph",
       },
     ],
     "object": "block",
@@ -2290,14 +2298,22 @@ Array [
     "isVoid": false,
     "nodes": Array [
       Object {
-        "leaves": Array [
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
           Object {
-            "marks": Array [],
-            "object": "leaf",
-            "text": "this is a quote",
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is a quote",
+              },
+            ],
+            "object": "text",
           },
         ],
-        "object": "text",
+        "object": "block",
+        "type": "paragraph",
       },
     ],
     "object": "block",
@@ -2316,14 +2332,22 @@ Array [
             "isVoid": false,
             "nodes": Array [
               Object {
-                "leaves": Array [
+                "data": Object {},
+                "isVoid": false,
+                "nodes": Array [
                   Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "this is a list item",
+                    "leaves": Array [
+                      Object {
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "this is a list item",
+                      },
+                    ],
+                    "object": "text",
                   },
                 ],
-                "object": "text",
+                "object": "block",
+                "type": "paragraph",
               },
             ],
             "object": "block",
@@ -2336,6 +2360,102 @@ Array [
     ],
     "object": "block",
     "type": "ordered-list",
+  },
+]
+`;
+
+exports[`parses quote with newlines and marks 1`] = `
+Array [
+  Object {
+    "data": Object {},
+    "isVoid": false,
+    "nodes": Array [
+      Object {
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
+          Object {
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is a ",
+              },
+              Object {
+                "marks": Array [
+                  Object {
+                    "data": Object {},
+                    "object": "mark",
+                    "type": "italic",
+                  },
+                ],
+                "object": "leaf",
+                "text": "quote",
+              },
+            ],
+            "object": "text",
+          },
+        ],
+        "object": "block",
+        "type": "paragraph",
+      },
+      Object {
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
+          Object {
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is the second part of the quote",
+              },
+            ],
+            "object": "text",
+          },
+        ],
+        "object": "block",
+        "type": "paragraph",
+      },
+      Object {
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
+          Object {
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "",
+              },
+            ],
+            "object": "text",
+          },
+        ],
+        "object": "block",
+        "type": "paragraph",
+      },
+      Object {
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
+          Object {
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is the third part of the quote",
+              },
+            ],
+            "object": "text",
+          },
+        ],
+        "object": "block",
+        "type": "paragraph",
+      },
+    ],
+    "object": "block",
+    "type": "block-quote",
   },
 ]
 `;
@@ -2910,14 +3030,22 @@ Array [
     "isVoid": false,
     "nodes": Array [
       Object {
-        "leaves": Array [
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
           Object {
-            "marks": Array [],
-            "object": "leaf",
-            "text": "this is a quote",
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is a quote",
+              },
+            ],
+            "object": "text",
           },
         ],
-        "object": "text",
+        "object": "block",
+        "type": "paragraph",
       },
     ],
     "object": "block",
@@ -2969,14 +3097,22 @@ Array [
     "isVoid": false,
     "nodes": Array [
       Object {
-        "leaves": Array [
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
           Object {
-            "marks": Array [],
-            "object": "leaf",
-            "text": "this is a quote",
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is a quote",
+              },
+            ],
+            "object": "text",
           },
         ],
-        "object": "text",
+        "object": "block",
+        "type": "paragraph",
       },
     ],
     "object": "block",
@@ -3005,14 +3141,22 @@ Array [
     "isVoid": false,
     "nodes": Array [
       Object {
-        "leaves": Array [
+        "data": Object {},
+        "isVoid": false,
+        "nodes": Array [
           Object {
-            "marks": Array [],
-            "object": "leaf",
-            "text": "this is a different quote",
+            "leaves": Array [
+              Object {
+                "marks": Array [],
+                "object": "leaf",
+                "text": "this is a different quote",
+              },
+            ],
+            "object": "text",
           },
         ],
-        "object": "text",
+        "object": "block",
+        "type": "paragraph",
       },
     ],
     "object": "block",

--- a/src/__tests__/renderer-test.js
+++ b/src/__tests__/renderer-test.js
@@ -144,6 +144,16 @@ test("parses quote followed by list with quote (outline/#723)", () => {
   expect(getNodes(text)).toMatchSnapshot();
 });
 
+test("parses quote with newlines and marks", () => {
+  const text = `
+> this is a *quote*
+> this is the second part of the quote
+>
+> this is the third part of the quote
+`;
+  expect(getNodes(text)).toMatchSnapshot();
+});
+
 test("quotes do not get combined", () => {
   const text = `
 > this is a quote

--- a/src/__tests__/renderer-test.js
+++ b/src/__tests__/renderer-test.js
@@ -139,7 +139,9 @@ test("parses quote", () => {
 test("parses quote followed by list with quote (outline/#723)", () => {
   const text = `
 > this is a quote
-1. > this is a list item
+1. > this is a list item with a quote
+
+> 1. this is a quote with a list item
 `;
   expect(getNodes(text)).toMatchSnapshot();
 });

--- a/src/__tests__/renderer-test.js
+++ b/src/__tests__/renderer-test.js
@@ -142,6 +142,7 @@ test("parses quote followed by list with quote (outline/#723)", () => {
 1. > this is a list item with a quote
 
 > 1. this is a quote with a list item
+> 2. this is the second list item
 `;
   expect(getNodes(text)).toMatchSnapshot();
 });

--- a/src/parser.js
+++ b/src/parser.js
@@ -1094,7 +1094,11 @@ Parser.prototype.tok = function() {
       let body = [];
 
       while (this.next().type !== "blockquote_end") {
-        body.push(this.inline.parse(this.token.text));
+        body.push(
+          this.token.type === "text"
+            ? this.renderer.paragraph(this.inline.parse(this.token.text))
+            : this.tok()
+        );
       }
       return this.renderer.blockquote(body);
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -68,7 +68,8 @@ const RULES = [
         case "code-line":
           return `${children}\n`;
         case "block-quote":
-          return `> ${children}`;
+          // Handle multi-line blockquotes
+          return children.split('\n').map((text) => `> ${text}`).join('\n');
         case "todo-list":
         case "bulleted-list":
         case "ordered-list": {
@@ -213,10 +214,13 @@ class Markdown {
       });
     }
 
-    let children = node.nodes.map(node => this.serializeNode(node, document));
-    children = children.flatten().length === 0
-      ? ""
-      : children.flatten().join("");
+    const children = node.nodes.map((childNode) => {
+      const serialized = this.serializeNode(childNode, document);
+      return ((serialized && serialized.join) ? serialized.join("") : serialized) || "";
+    }).join(
+      // Special case for blockquotes, children in blockquotes are separated by new lines
+      node.type === "block-quote" ? "\n" : ""
+    );
 
     for (const rule of this.rules) {
       if (!rule.serialize) continue;


### PR DESCRIPTION
Multi-line blockquotes weren't being parsed correctly so I took a stab at solving it.  Not sure if I found the correct solution though.

Issue:
```
> Quote1
>
> Quote2
```
Was incorrectly creating a blockquote with text `"Quote1Quote2"`