### PR TITLE
Start conditionally escaping chars, starting with period

### DIFF
--- a/src/__tests__/utils-test.js
+++ b/src/__tests__/utils-test.js
@@ -1,0 +1,36 @@
+import { escapeMarkdownChars } from "../utils";
+
+describe("escapeMarkdownChars", () => {
+  test("handles headings", () => {
+    expect(escapeMarkdownChars("# text")).toEqual("\\# text");
+  });
+
+  test("handles unordered list items", () => {
+    expect(escapeMarkdownChars("- text")).toEqual("\\- text");
+    expect(escapeMarkdownChars("* text")).toEqual("\\* text");
+  });
+
+  test("handles bolds", () => {
+    expect(escapeMarkdownChars("this is **not bold**")).toEqual("this is \\*\\*not bold\\*\\*");
+  });
+
+  test("handles italics", () => {
+    expect(escapeMarkdownChars("this is *not italic*")).toEqual("this is \\*not italic\\*");
+  });
+
+  test("handles links", () => {
+    expect(escapeMarkdownChars("this is [not](a link)")).toEqual("this is \\[not\\]\\(a link\\)");
+  });
+
+  test("handles images", () => {
+    expect(escapeMarkdownChars("this is ![not](an image)")).toEqual("this is \\!\\[not\\]\\(an image\\)");
+  });
+
+  test("handles ordered list items", () => {
+    expect(escapeMarkdownChars(" 1a. item.")).toEqual(" 1a\\. item.");
+  });
+
+  test("does not escape links", () => {
+    expect(escapeMarkdownChars("https://github.com/")).toEqual("https://github.com/");
+  });
+});

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -2,6 +2,7 @@ import parser from "./parser";
 import { Value } from "slate";
 import { Record } from "immutable";
 import { encode } from "./urls";
+import { escapeMarkdownChars } from "./utils";
 
 const String = new Record({
   object: "string",
@@ -232,7 +233,7 @@ class Markdown {
     let leavesText = leaves.text;
     if (escape) {
       // escape markdown characters
-      leavesText = leavesText.replace(/([\\`*{}\[\]()#+\-.!_>])/gi, "\\$1");
+      leavesText = escapeMarkdownChars(leavesText);
     }
     const string = new String({ text: leavesText });
     const text = this.serializeString(string);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+export function escapeMarkdownChars(text: string): string {
+  let result = text;
+
+  // First replace all backslashes because we are adding backslashes in this function
+  result = result.replace(/([\\])/gi, "\\$1");
+
+  // Periods only happen in ordered lists
+  result = result.replace(/^(\s*\w+)\./gi, "$1\\.");
+
+  // Catch all escaping for certain characters
+  // TODO: situationally escape these characters so we don't overescape
+  return result.replace(/([`*{}\[\]()#+\-!_>])/gi, "\\$1");
+}


### PR DESCRIPTION
This addresses https://github.com/tommoor/slate-md-serializer/issues/14 by starting to conditionally escape characters.  I added tests for periods because it was affecting links.  I also pulled this out into a utility so that tests would be separate from the renderer.