### PR TITLE
Properly escape greater than sign (blockquote)

### DIFF
--- a/src/__tests__/utils-test.js
+++ b/src/__tests__/utils-test.js
@@ -48,9 +48,17 @@ describe("escapeMarkdownChars", () => {
     expect(escapeMarkdownChars(" 1a. item.")).toEqual(" 1a\\. item.");
   });
 
+  test("handles blockquotes", () => {
+    expect(escapeMarkdownChars(" > quote")).toEqual(" \\> quote");
+  });
+
   test("does not escape links", () => {
     expect(escapeMarkdownChars("https://github.com/")).toEqual(
       "https://github.com/"
     );
+  });
+
+  test("does not HTML", () => {
+    expect(escapeMarkdownChars("<br>")).toEqual("<br>");
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,10 @@ export function escapeMarkdownChars(text: string): string {
   // Hashtags shouldn't be escaped, but elsewhere should
   result = result.replace(/(#\s)/gi, "\\$1");
 
+  // Catch blockquotes at beginning of line
+  result = result.replace(/^(\s*)>/gi, "$1\\>");
+
   // Catch all escaping for certain characters
   // TODO: situationally escape these characters so we don't overescape
-  return result.replace(/([`*{}\[\]()+\-!_>])/gi, "\\$1");
+  return result.replace(/([`*{}\[\]()+\-!_])/gi, "\\$1");
 }


### PR DESCRIPTION
This is so that HTML is not improperly escaped.