### PR TITLE
Update to latest version of Slate

### DIFF
--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -8,13 +8,7 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "bold",
-              },
-            ],
+            "marks": Array [],
             "object": "leaf",
             "text": "this is bold",
           },
@@ -129,13 +123,7 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "code",
-              },
-            ],
+            "marks": Array [],
             "object": "leaf",
             "text": "const foo = 123;",
           },
@@ -157,15 +145,79 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "code",
-              },
-            ],
+            "marks": Array [],
             "object": "leaf",
-            "text": "<script>alert('foo')</script>",
+            "text": "<script",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": ">",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "alert",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "(",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "'foo'",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": ")",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "</script",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": ">",
           },
         ],
         "object": "text",
@@ -185,13 +237,7 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "deleted",
-              },
-            ],
+            "marks": Array [],
             "object": "leaf",
             "text": "this is strikethrough",
           },
@@ -248,21 +294,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "list",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "list",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -301,7 +340,7 @@ function() {
 \`\`\`"
 `;
 
-exports[`does not escape characters inside of code marks 1`] = `"\`<script>alert('foo')</script>\`"`;
+exports[`does not escape characters inside of code marks 1`] = `"<script\\\\>alert\\\\('foo'\\\\)</script\\\\>"`;
 
 exports[`does not parse marks around code block boundaries 1`] = `
 Array [
@@ -357,7 +396,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "* bold",
+            "text": "*",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": " bold",
           },
         ],
         "object": "text",
@@ -401,14 +450,14 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "# text",
+            "text": "text",
           },
         ],
         "object": "text",
       },
     ],
     "object": "block",
-    "type": "paragraph",
+    "type": "heading1",
   },
 ]
 `;
@@ -423,7 +472,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "- text",
+            "text": "-",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": " text",
           },
         ],
         "object": "text",
@@ -445,7 +504,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "* text",
+            "text": "*",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": " text",
           },
         ],
         "object": "text",
@@ -487,7 +556,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "*not bold",
+            "text": "*",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "not bold",
           },
         ],
         "object": "text",
@@ -539,7 +618,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "*not italic",
+            "text": "*",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "not italic",
           },
         ],
         "object": "text",
@@ -581,7 +670,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "[not",
+            "text": "[",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "not",
           },
         ],
         "object": "text",
@@ -601,7 +700,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "(a link",
+            "text": "(",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "a link",
           },
         ],
         "object": "text",
@@ -653,7 +762,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "[not",
+            "text": "[",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "not",
           },
         ],
         "object": "text",
@@ -673,7 +792,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "(an image",
+            "text": "(",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "an image",
           },
         ],
         "object": "text",
@@ -859,13 +988,7 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "inserted",
-              },
-            ],
+            "marks": Array [],
             "object": "leaf",
             "text": "inserted text",
           },
@@ -887,31 +1010,9 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "italic",
-              },
-            ],
-            "object": "leaf",
-            "text": "this is italic",
-          },
-          Object {
             "marks": Array [],
             "object": "leaf",
-            "text": " ",
-          },
-          Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "italic",
-              },
-            ],
-            "object": "leaf",
-            "text": "this is italic too",
+            "text": "this is italic this is italic too",
           },
         ],
         "object": "text",
@@ -1084,21 +1185,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "checked",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "checked",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
           Object {
             "data": Object {},
@@ -1109,21 +1203,14 @@ Array [
                 },
                 "nodes": Array [
                   Object {
-                    "data": Object {},
-                    "nodes": Array [
+                    "leaves": Array [
                       Object {
-                        "leaves": Array [
-                          Object {
-                            "marks": Array [],
-                            "object": "leaf",
-                            "text": "empty",
-                          },
-                        ],
-                        "object": "text",
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "empty",
                       },
                     ],
-                    "object": "block",
-                    "type": "paragraph",
+                    "object": "text",
                   },
                 ],
                 "object": "block",
@@ -1135,21 +1222,14 @@ Array [
                 },
                 "nodes": Array [
                   Object {
-                    "data": Object {},
-                    "nodes": Array [
+                    "leaves": Array [
                       Object {
-                        "leaves": Array [
-                          Object {
-                            "marks": Array [],
-                            "object": "leaf",
-                            "text": "checked",
-                          },
-                        ],
-                        "object": "text",
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "checked",
                       },
                     ],
-                    "object": "block",
-                    "type": "paragraph",
+                    "object": "text",
                   },
                 ],
                 "object": "block",
@@ -1176,21 +1256,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "three",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "three",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1311,7 +1384,17 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "-dash",
+            "text": "-",
+          },
+        ],
+        "object": "text",
+      },
+      Object {
+        "leaves": Array [
+          Object {
+            "marks": Array [],
+            "object": "leaf",
+            "text": "dash",
           },
         ],
         "object": "text",
@@ -1577,21 +1660,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1601,21 +1677,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1761,21 +1830,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1785,21 +1847,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1821,32 +1876,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one ",
-                  },
-                  Object {
-                    "marks": Array [
-                      Object {
-                        "data": Object {},
-                        "object": "mark",
-                        "type": "bold",
-                      },
-                    ],
-                    "object": "leaf",
-                    "text": "bold",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one bold",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1856,32 +1893,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [
-                      Object {
-                        "data": Object {},
-                        "object": "mark",
-                        "type": "italic",
-                      },
-                    ],
-                    "object": "leaf",
-                    "text": "italic",
-                  },
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": " two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "italic two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1903,21 +1922,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "list",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "list",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1934,21 +1946,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "another",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "another",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -1965,21 +1970,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "different",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "different",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2001,21 +1999,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2025,21 +2016,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
           Object {
             "data": Object {},
@@ -2048,21 +2032,14 @@ Array [
                 "data": Object {},
                 "nodes": Array [
                   Object {
-                    "data": Object {},
-                    "nodes": Array [
+                    "leaves": Array [
                       Object {
-                        "leaves": Array [
-                          Object {
-                            "marks": Array [],
-                            "object": "leaf",
-                            "text": "nested",
-                          },
-                        ],
-                        "object": "text",
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "nested",
                       },
                     ],
-                    "object": "block",
-                    "type": "paragraph",
+                    "object": "text",
                   },
                 ],
                 "object": "block",
@@ -2111,21 +2088,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "todo",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "todo",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
           Object {
             "data": Object {},
@@ -2136,21 +2106,14 @@ Array [
                 },
                 "nodes": Array [
                   Object {
-                    "data": Object {},
-                    "nodes": Array [
+                    "leaves": Array [
                       Object {
-                        "leaves": Array [
-                          Object {
-                            "marks": Array [],
-                            "object": "leaf",
-                            "text": "nested",
-                          },
-                        ],
-                        "object": "text",
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "nested",
                       },
                     ],
-                    "object": "block",
-                    "type": "paragraph",
+                    "object": "text",
                   },
                 ],
                 "object": "block",
@@ -2162,21 +2125,14 @@ Array [
                 },
                 "nodes": Array [
                   Object {
-                    "data": Object {},
-                    "nodes": Array [
+                    "leaves": Array [
                       Object {
-                        "leaves": Array [
-                          Object {
-                            "marks": Array [],
-                            "object": "leaf",
-                            "text": "deep",
-                          },
-                        ],
-                        "object": "text",
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "deep",
                       },
                     ],
-                    "object": "block",
-                    "type": "paragraph",
+                    "object": "text",
                   },
                 ],
                 "object": "block",
@@ -2206,21 +2162,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2230,21 +2179,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2266,21 +2208,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2290,21 +2225,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2314,21 +2242,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "three",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "three",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2350,32 +2271,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "one ",
-                  },
-                  Object {
-                    "marks": Array [
-                      Object {
-                        "data": Object {},
-                        "object": "mark",
-                        "type": "bold",
-                      },
-                    ],
-                    "object": "leaf",
-                    "text": "bold",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "one bold",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2385,32 +2288,14 @@ Array [
         "data": Object {},
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [
-                      Object {
-                        "data": Object {},
-                        "object": "mark",
-                        "type": "italic",
-                      },
-                    ],
-                    "object": "leaf",
-                    "text": "italic",
-                  },
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": " two",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "italic two",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -2548,21 +2433,14 @@ Array [
             "data": Object {},
             "nodes": Array [
               Object {
-                "data": Object {},
-                "nodes": Array [
+                "leaves": Array [
                   Object {
-                    "leaves": Array [
-                      Object {
-                        "marks": Array [],
-                        "object": "leaf",
-                        "text": "this is a quote with a list item",
-                      },
-                    ],
-                    "object": "text",
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "this is a quote with a list item",
                   },
                 ],
-                "object": "block",
-                "type": "paragraph",
+                "object": "text",
               },
             ],
             "object": "block",
@@ -2572,21 +2450,14 @@ Array [
             "data": Object {},
             "nodes": Array [
               Object {
-                "data": Object {},
-                "nodes": Array [
+                "leaves": Array [
                   Object {
-                    "leaves": Array [
-                      Object {
-                        "marks": Array [],
-                        "object": "leaf",
-                        "text": "this is the second list item",
-                      },
-                    ],
-                    "object": "text",
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "this is the second list item",
                   },
                 ],
-                "object": "block",
-                "type": "paragraph",
+                "object": "text",
               },
             ],
             "object": "block",
@@ -2616,18 +2487,7 @@ Array [
               Object {
                 "marks": Array [],
                 "object": "leaf",
-                "text": "this is a ",
-              },
-              Object {
-                "marks": Array [
-                  Object {
-                    "data": Object {},
-                    "object": "mark",
-                    "type": "italic",
-                  },
-                ],
-                "object": "leaf",
-                "text": "quote",
+                "text": "this is a quote",
               },
             ],
             "object": "text",
@@ -2805,7 +2665,17 @@ Array [
                   Object {
                     "marks": Array [],
                     "object": "leaf",
-                    "text": "-aligned",
+                    "text": "-",
+                  },
+                ],
+                "object": "text",
+              },
+              Object {
+                "leaves": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "aligned",
                   },
                 ],
                 "object": "text",
@@ -2943,7 +2813,17 @@ Array [
                   Object {
                     "marks": Array [],
                     "object": "leaf",
-                    "text": "-aligned",
+                    "text": "-",
+                  },
+                ],
+                "object": "text",
+              },
+              Object {
+                "leaves": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "aligned",
                   },
                 ],
                 "object": "text",
@@ -2993,21 +2873,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "todo",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "todo",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -3019,21 +2892,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "done",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "done",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -3057,27 +2923,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [
-                      Object {
-                        "data": Object {},
-                        "object": "mark",
-                        "type": "deleted",
-                      },
-                    ],
-                    "object": "leaf",
-                    "text": "done",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "done",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -3089,32 +2942,14 @@ Array [
         },
         "nodes": Array [
           Object {
-            "data": Object {},
-            "nodes": Array [
+            "leaves": Array [
               Object {
-                "leaves": Array [
-                  Object {
-                    "marks": Array [],
-                    "object": "leaf",
-                    "text": "more ",
-                  },
-                  Object {
-                    "marks": Array [
-                      Object {
-                        "data": Object {},
-                        "object": "mark",
-                        "type": "bold",
-                      },
-                    ],
-                    "object": "leaf",
-                    "text": "done",
-                  },
-                ],
-                "object": "text",
+                "marks": Array [],
+                "object": "leaf",
+                "text": "more done",
               },
             ],
-            "object": "block",
-            "type": "paragraph",
+            "object": "text",
           },
         ],
         "object": "block",
@@ -3488,7 +3323,17 @@ Array [
                   Object {
                     "marks": Array [],
                     "object": "leaf",
-                    "text": "-aligned",
+                    "text": "-",
+                  },
+                ],
+                "object": "text",
+              },
+              Object {
+                "leaves": Array [
+                  Object {
+                    "marks": Array [],
+                    "object": "leaf",
+                    "text": "aligned",
                   },
                 ],
                 "object": "text",
@@ -3569,13 +3414,7 @@ Array [
       Object {
         "leaves": Array [
           Object {
-            "marks": Array [
-              Object {
-                "data": Object {},
-                "object": "mark",
-                "type": "underlined",
-              },
-            ],
+            "marks": Array [],
             "object": "leaf",
             "text": "underlined text",
           },

--- a/src/parser.js
+++ b/src/parser.js
@@ -1148,7 +1148,7 @@ Parser.prototype.tok = function() {
       while (this.next().type !== "list_item_end") {
         body.push(
           this.token.type === "text"
-            ? this.renderer.paragraph(this.inline.parse(this.token.text))
+            ? this.inline.parse(this.token.text)
             : this.tok()
         );
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -18,13 +18,7 @@ const hashtag = new RegExp(
 const EMPTY_PARAGRAPH_NODES = [
   {
     object: "text",
-    leaves: [
-      {
-        object: "leaf",
-        text: "",
-        marks: []
-      }
-    ]
+    text: ""
   }
 ];
 
@@ -593,11 +587,7 @@ InlineLexer.prototype.parse = function(src) {
       src = src.substring(cap[0].length);
       out.push({
         object: "text",
-        leaves: [
-          {
-            text: cap[1]
-          }
-        ]
+        text: cap[1]
       });
       continue;
     }
@@ -628,11 +618,7 @@ InlineLexer.prototype.parse = function(src) {
       if (!link || !link.href) {
         out.push({
           object: "text",
-          leaves: [
-            {
-              text: cap[0].charAt(0)
-            }
-          ]
+          text: cap[0].charAt(0)
         });
         src = cap[0].substring(1) + src;
         continue;
@@ -729,23 +715,11 @@ function Renderer(options) {
 Renderer.prototype.groupTextInLeaves = function(childNode) {
   let node = flatten(childNode);
   const output = node.reduce((acc, current) => {
-    let accLast = acc.length - 1;
-    let lastIsText =
-      accLast >= 0 && acc[accLast] && acc[accLast]["object"] === "text";
-
     if (current.text) {
-      if (lastIsText) {
-        // If the previous item was a text object, push the current text to it's range
-        acc[accLast].leaves.push(current);
-        return acc;
-      } else {
-        // Else, create a new text object
-        acc.push({
-          object: "text",
-          leaves: [current]
-        });
-        return acc;
-      }
+      acc.push(
+        assign({}, current, {object: "text"})
+      );
+      return acc;
     } else if (current instanceof Array) {
       return acc.concat(this.groupTextInLeaves(current));
     } else {
@@ -931,7 +905,7 @@ Renderer.prototype.hashtag = function(childNode) {
     nodes: [
       {
         object: "text",
-        leaves: [{ text: childNode }]
+        text: childNode
       }
     ]
   };
@@ -1056,11 +1030,7 @@ Parser.prototype.tok = function() {
     case "space": {
       return {
         object: "text",
-        leaves: [
-          {
-            text: ""
-          }
-        ]
+        text: ""
       };
     }
     case "hr": {
@@ -1078,7 +1048,7 @@ Parser.prototype.tok = function() {
         [
           {
             object: "text",
-            leaves: [{ text: this.token.text }]
+            text: this.token.text
           }
         ],
         this.token.lang
@@ -1212,18 +1182,11 @@ const MarkdownParser = {
             nodes: [
               {
                 object: "text",
-                leaves: [
-                  {
-                    object: "leaf",
-                    text: "An error occured:",
-                    marks: []
-                  },
-                  {
-                    object: "leaf",
-                    text: e.message,
-                    marks: []
-                  }
-                ]
+                text: "An error occured:"
+              },
+              {
+                object: "text",
+                text: e.message
               }
             ]
           }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -205,17 +205,13 @@ class Markdown {
 
   serializeNode(node, document) {
     if (node.object == "text") {
-      const leaves = node.getLeaves();
       const inCodeBlock = !!document.getClosest(
         node.key,
         n => n.type === "code"
       );
-
-      return leaves.map(leave => {
-        const inCodeMark = !!leave.marks.filter(mark => mark.type === "code")
-          .size;
-        return this.serializeLeaves(leave, !inCodeBlock && !inCodeMark);
-      });
+      const inCodeMark = !!(node.marks || []).filter(mark => mark.type === "code")
+        .size;
+      return this.serializeLeaves(node, !inCodeBlock && !inCodeMark);
     }
 
     const children = node.nodes
@@ -254,7 +250,7 @@ class Markdown {
     const string = new String({ text: leavesText });
     const text = this.serializeString(string);
 
-    return leaves.marks.reduce((children, mark) => {
+    return (leaves.marks || []).reduce((children, mark) => {
       for (const rule of this.rules) {
         if (!rule.serialize) continue;
         const ret = rule.serialize(mark, children);


### PR DESCRIPTION
Hi all.

I've recently started using Slate and came across this Markdown serialiser. After reading #27, I learned that this fork is not compatible with the latest version (0.47), so I had a go at making the necessary changes, which are included in this PR.

The main change was to remove the `leaves` property from `text` objects. Slate was throwing deprecation warnings before, which this PR fixes.

I've also made a change to how list items are processed (https://github.com/tommoor/slate-md-serializer/compare/master...edithq:master#diff-6947033678b93d106e25614dd972e66fL1151), so that list items are not wrapped inside a paragraph node. I'm not sure this is a result of any changes in Slate core, but the reality is that my list items were not being rendered properly and this seems to fix it.

@tommoor I assume you're probably not interested in merging this at this point, because from what I gather you're pegged to an older version of Slate, but if you could kindly glance over this PR and let me know if there's something blatantly wrong in the implementation, that would be much appreciated.

If you're happy with it, perhaps we can leave the PR open and we can merge our forks again once you're happy to upgrade.

Thanks!