### PR TITLE
Fix incorrect identifier name in parser.js

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1220,7 +1220,7 @@ const MarkdownParser = {
                   },
                   {
                     object: "leaf",
-                    text: e.message,
+                    text: err.message,
                     marks: []
                   }
                 ]


### PR DESCRIPTION
Super simple PR. I think you meant to call `err.message` instead of `e.message`.