### PR TITLE
Table blocks should be surrounded by newline characters

### DIFF
--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -4109,6 +4109,32 @@ Array [
             "object": "block",
             "type": "table-cell",
           },
+          Object {
+            "data": Object {
+              "align": "right",
+            },
+            "nodes": Array [
+              Object {
+                "data": Object {},
+                "nodes": Array [
+                  Object {
+                    "leaves": Array [
+                      Object {
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "",
+                      },
+                    ],
+                    "object": "text",
+                  },
+                ],
+                "object": "block",
+                "type": "paragraph",
+              },
+            ],
+            "object": "block",
+            "type": "table-cell",
+          },
         ],
         "object": "block",
         "type": "table-row",

--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -3743,23 +3743,6 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "",
-          },
-        ],
-        "object": "text",
-      },
-    ],
-    "object": "block",
-    "type": "paragraph",
-  },
-  Object {
-    "data": Object {},
-    "nodes": Array [
-      Object {
-        "leaves": Array [
-          Object {
-            "marks": Array [],
-            "object": "leaf",
             "text": "a new paragraph",
           },
         ],
@@ -3960,23 +3943,6 @@ Array [
     ],
     "object": "block",
     "type": "table",
-  },
-  Object {
-    "data": Object {},
-    "nodes": Array [
-      Object {
-        "leaves": Array [
-          Object {
-            "marks": Array [],
-            "object": "leaf",
-            "text": "",
-          },
-        ],
-        "object": "text",
-      },
-    ],
-    "object": "block",
-    "type": "paragraph",
   },
   Object {
     "data": Object {},

--- a/src/parser.js
+++ b/src/parser.js
@@ -284,6 +284,11 @@ Lexer.prototype.token = function(src, top, bq) {
 
       this.tokens.push(item);
 
+      // New line character directly after table is part of the syntax and should be ignored
+      if ((cap = /^\n/.exec(src))) {
+        src = src.substring(cap[0].length);
+      }
+
       continue;
     }
 
@@ -436,6 +441,11 @@ Lexer.prototype.token = function(src, top, bq) {
       }
 
       this.tokens.push(item);
+
+      // New line character directly after table is part of the syntax and should be ignored
+      if ((cap = /^\n/.exec(src))) {
+        src = src.substring(cap[0].length);
+      }
 
       continue;
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -419,7 +419,7 @@ Lexer.prototype.token = function(src, top, bq) {
         type: "table",
         header: splitCells(cap[1].replace(/^ *| *\| *$/g, "")),
         align: cap[2].replace(/^ *|\| *$/g, "").split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, "").split("\n")
+        cells: cap[3].replace(/\n$/, "").split("\n")
       };
 
       for (i = 0; i < item.align.length; i++) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -202,7 +202,11 @@ Lexer.prototype.token = function(src, top, bq) {
       src = src.substring(cap[0].length);
       const newlines = cap[0].length;
 
-      if (top) {
+      // special case: a newline prepending a table block should not be
+      // interpreted as an empty paragraph.
+      const aboutToParseTable = this.rules.nptable.exec(src) || this.rules.table.exec(src);
+
+      if (top && !aboutToParseTable) {
         for (let i = 0; i < newlines; i++) {
           this.tokens.push({
             type: "paragraph",

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -36,8 +36,8 @@ const RULES = [
           tableHeader = "";
           firstRow = true;
 
-          // trim removes trailing newline
-          return children.trim();
+          // table blocks should be surrounded by newline characters
+          return "\n" + children.trim() + "\n";
         case "table-cell": {
           switch (obj.getIn(["data", "align"])) {
             case "left":


### PR DESCRIPTION
This PR changes the way that tables are serialized to Markdown by wrapping them with newline characters. A slight modification was made to how markdown is parsed into nodes, to avoid that these wrapping new lines are interpreted as "blank line paragraphs".

The change takes backwards compatibility into account, in the way that both tables in the old syntax (without wrapping newline) and the new syntax (with wrapping newline) will be parsed correctly.

Therefore this change should not break existing markdown documents that was created using the old version of slate-md-serializer.

Edit: This fixes the issue described here: https://github.com/tommoor/slate-md-serializer/issues/38