### PR TITLE
Table blocks should be surround by newline characters

### DIFF
--- a/src/__tests__/__snapshots__/renderer-test.js.snap
+++ b/src/__tests__/__snapshots__/renderer-test.js.snap
@@ -3743,23 +3743,6 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "",
-          },
-        ],
-        "object": "text",
-      },
-    ],
-    "object": "block",
-    "type": "paragraph",
-  },
-  Object {
-    "data": Object {},
-    "nodes": Array [
-      Object {
-        "leaves": Array [
-          Object {
-            "marks": Array [],
-            "object": "leaf",
             "text": "a new paragraph",
           },
         ],
@@ -3969,23 +3952,6 @@ Array [
           Object {
             "marks": Array [],
             "object": "leaf",
-            "text": "",
-          },
-        ],
-        "object": "text",
-      },
-    ],
-    "object": "block",
-    "type": "paragraph",
-  },
-  Object {
-    "data": Object {},
-    "nodes": Array [
-      Object {
-        "leaves": Array [
-          Object {
-            "marks": Array [],
-            "object": "leaf",
             "text": "a new paragraph",
           },
         ],
@@ -4120,6 +4086,32 @@ Array [
           Object {
             "data": Object {
               "align": "center",
+            },
+            "nodes": Array [
+              Object {
+                "data": Object {},
+                "nodes": Array [
+                  Object {
+                    "leaves": Array [
+                      Object {
+                        "marks": Array [],
+                        "object": "leaf",
+                        "text": "",
+                      },
+                    ],
+                    "object": "text",
+                  },
+                ],
+                "object": "block",
+                "type": "paragraph",
+              },
+            ],
+            "object": "block",
+            "type": "table-cell",
+          },
+          Object {
+            "data": Object {
+              "align": "right",
             },
             "nodes": Array [
               Object {

--- a/src/parser.js
+++ b/src/parser.js
@@ -202,7 +202,11 @@ Lexer.prototype.token = function(src, top, bq) {
       src = src.substring(cap[0].length);
       const newlines = cap[0].length;
 
-      if (top) {
+      // special case: a newline prepending a table block should not be
+      // interpreted as an empty paragraph.
+      const aboutToParseTable = this.rules.nptable.exec(src) || this.rules.table.exec(src);
+
+      if (top && !aboutToParseTable) {
         for (let i = 0; i < newlines; i++) {
           this.tokens.push({
             type: "paragraph",
@@ -279,6 +283,11 @@ Lexer.prototype.token = function(src, top, bq) {
       }
 
       this.tokens.push(item);
+
+      // New line character directly after table is part of the syntax and should be ignored
+      if ((cap = /^\n/.exec(src))) {
+        src = src.substring(cap[0].length);
+      }
 
       continue;
     }
@@ -410,7 +419,7 @@ Lexer.prototype.token = function(src, top, bq) {
         type: "table",
         header: splitCells(cap[1].replace(/^ *| *\| *$/g, "")),
         align: cap[2].replace(/^ *|\| *$/g, "").split(/ *\| */),
-        cells: cap[3].replace(/(?: *\| *)?\n$/, "").split("\n")
+        cells: cap[3].replace(/\n$/, "").split("\n")
       };
 
       for (i = 0; i < item.align.length; i++) {
@@ -432,6 +441,11 @@ Lexer.prototype.token = function(src, top, bq) {
       }
 
       this.tokens.push(item);
+
+      // New line character directly after table is part of the syntax and should be ignored
+      if ((cap = /^\n/.exec(src))) {
+        src = src.substring(cap[0].length);
+      }
 
       continue;
     }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -36,8 +36,8 @@ const RULES = [
           tableHeader = "";
           firstRow = true;
 
-          // trim removes trailing newline
-          return children.trim();
+          // table blocks should be surrounded by newline characters
+          return "\n" + children.trim() + "\n";
         case "table-cell": {
           switch (obj.getIn(["data", "align"])) {
             case "left":


### PR DESCRIPTION
Hi!

This is an improved version of a previous PR that fixes the table syntax issue described here: https://github.com/tommoor/slate-md-serializer/issues/40 

* Updated renderer to surround table blocks with newline characters
* Updated parser to interpret surrounding newline characters (if present) as part of the table block syntax to avoid the creation of excess paragraph nodes
* The parser previously skipped the last cell in a table if it was empty (caused by the regexp `cap[3].replace(/(?: *\| *)?\n$/, "")`). Fixed this and updated test to expect all cells (even empty) to be properly parsed.